### PR TITLE
Fix sum KL distribution across both latent dims.

### DIFF
--- a/dreamerv2/common/nets.py
+++ b/dreamerv2/common/nets.py
@@ -78,7 +78,7 @@ class EnsembleRSSM(common.Module):
     if self._discrete:
       logit = state['logit']
       logit = tf.cast(logit, tf.float32)
-      dist = tfd.Independent(common.OneHotDist(logit), 1)
+      dist = tfd.Independent(common.OneHotDist(logit), 2)
     else:
       mean, std = state['mean'], state['std']
       mean = tf.cast(mean, tf.float32)


### PR DESCRIPTION
Logits have shape `TensorShape([2, 32, 32])`, I believe you want to sum over the last two latent dimensions when you are computing the KL divergence loss.